### PR TITLE
Check for "Authorization" only among headers.

### DIFF
--- a/RestSharp.Portable.OAuth2/OAuth2Authenticator.cs
+++ b/RestSharp.Portable.OAuth2/OAuth2Authenticator.cs
@@ -146,7 +146,7 @@ namespace RestSharp.Portable.Authenticators
         public override async Task Authenticate(IRestClient client, IRestRequest request)
         {
             // only add the Authorization parameter if it hasn't been added.
-            if (request.Parameters.Any(p => p.Name.Equals("Authorization", StringComparison.OrdinalIgnoreCase)))
+            if (request.Parameters.Any(p => p.Type == ParameterType.HttpHeader && p.Name.Equals("Authorization", StringComparison.OrdinalIgnoreCase)))
                 return;
 
             var authValue = string.Format("{0} {1}", _tokenType, await _client.GetCurrentToken());


### PR DESCRIPTION
`OAuth2Authenticator` completely fails on `POST` requests with payload as it called `p.Name.Equals` and payload is added as parameter with `Name = null`.

Such check prevents this error and also possibility of name clash with GET parameter or cookie.

Please update NuGet package after merging this PR.
