### PR TITLE
AsyncLock fixes

### DIFF
--- a/RestSharp.Portable/AsyncLock.cs
+++ b/RestSharp.Portable/AsyncLock.cs
@@ -49,10 +49,11 @@ namespace RestSharp.Portable
         {
             lock (_syncObject)
             {
-                if (_isDisposed)
-                    return;
-                _lock.Dispose();
-                _isDisposed = true;
+                if (_isDisposed == false)
+                {
+                    _isDisposed = true;
+                    _lock.Dispose();
+                }
             }
         }
 
@@ -67,11 +68,14 @@ namespace RestSharp.Portable
 
             public void Dispose()
             {
+                if (_toRelease._isDisposed == false)
+                {
 #if PCL || SILVERLIGHT || NET40
-                _toRelease._lock.Set();
+                    _toRelease._lock.Set();
 #else
-                _toRelease._lock.Release();
+                    _toRelease._lock.Release();
 #endif
+                }
             }
         }
     }


### PR DESCRIPTION
Case, which lead to the issue:
There is a separate view with the _RestClient_ used internally. When the view should be closed (using back navigation), it disposes the _RestClient_ regradless of running requests. Even if running tasks are cancelled, the _ObjectDisposedException_ could be thrown, if disposing occurred before the request is completed.