### PR TITLE
Added Content property to RestResponse

### DIFF
--- a/RestSharp.Portable.Core/IRestResponse.cs
+++ b/RestSharp.Portable.Core/IRestResponse.cs
@@ -48,5 +48,10 @@ namespace RestSharp.Portable
         /// Gets the description for the HTTP status code
         /// </summary>
         string StatusDescription { get; }
+
+        /// <summary>
+        /// String representation of response content
+        /// </summary>
+        string Content {get;}
     }
 }

--- a/RestSharp.Portable.Core/RestResponse.cs
+++ b/RestSharp.Portable.Core/RestResponse.cs
@@ -10,6 +10,8 @@ namespace RestSharp.Portable
     /// </summary>
     public class RestResponse : IRestResponse
     {
+        private string content;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="RestResponse" /> class.
         /// </summary>
@@ -60,6 +62,15 @@ namespace RestSharp.Portable
         /// Gets the description for the HTTP status code
         /// </summary>
         public string StatusDescription { get; private set; }
+
+        /// <summary>
+        /// String representation of response content
+        /// </summary>
+        public string Content
+        {
+            get { return this.content ?? (this.content = this.RawBytes.AsString()); }
+            set { this.content = value; }
+        }
 
         /// <summary>
         /// Gets the REST client that created this response

--- a/RestSharp.Portable.Core/RestResponseExtensions.cs
+++ b/RestSharp.Portable.Core/RestResponseExtensions.cs
@@ -1,0 +1,68 @@
+﻿using System.Text;
+using System.IO;
+
+namespace RestSharp.Portable
+{
+    /// <summary>
+    /// Extensions for <see cref="RestResponse"/>
+    /// </summary>
+    public static class RestResponseExtensions
+    {
+        /// <summary>
+        /// Converts a byte array to a string, using its byte order mark to convert it to the right encoding.
+        /// http://www.shrinkrays.net/code-snippets/csharp/an-extension-method-for-converting-a-byte-array-to-a-string.aspx
+        /// </summary>
+        /// <param name="buffer">An array of bytes to convert</param>
+        /// <returns>The byte as a string.</returns>
+        public static string AsString(this byte[] buffer)
+        {
+            if (buffer == null)
+            {
+                return "";
+            }
+
+            // Ansi as default
+            Encoding encoding = Encoding.UTF8;
+
+#if !PCL
+            return encoding.GetString(buffer, 0, buffer.Length);
+#else
+            if (buffer.Length == 0)
+                return "";
+
+            /*
+                EF BB BF            UTF-8 
+                FF FE UTF-16        little endian 
+                FE FF UTF-16        big endian 
+                FF FE 00 00         UTF-32, little endian 
+                00 00 FE FF         UTF-32, big-endian 
+            */
+
+            if (buffer[0] == 0xef && buffer[1] == 0xbb && buffer[2] == 0xbf)
+            {
+                encoding = Encoding.UTF8;
+            }
+            else if (buffer[0] == 0xfe && buffer[1] == 0xff)
+            {
+                encoding = Encoding.Unicode;
+            }
+            else if (buffer[0] == 0xfe && buffer[1] == 0xff)
+            {
+                encoding = Encoding.BigEndianUnicode; // utf-16be
+            }
+
+            using (MemoryStream stream = new MemoryStream())
+            {
+                stream.Write(buffer, 0, buffer.Length);
+                stream.Seek(0, SeekOrigin.Begin);
+
+                using (StreamReader reader = new StreamReader(stream, encoding))
+                {
+                    return reader.ReadToEnd();
+                }
+            }
+            #endif
+        }
+    }
+}
+

--- a/RestSharp.Portable.Core/RestSharp.Portable.Core.projitems
+++ b/RestSharp.Portable.Core/RestSharp.Portable.Core.projitems
@@ -64,5 +64,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)UrlEscapeFlags.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UrlEscapeUtility.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UrlUtility.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)RestResponseExtensions.cs" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This adds a `string` property called Content on the `IRestResponse` class.  Code "borrowed" from Restsharp as discussed in #63 

@fubar-coder please check all builds on CI or locally as I couldn't open the SL5 and UWP projects so couldn't build the solution 😢 