### PR TITLE
ensure that the correct httpclientfactory is used in restclientbase

### DIFF
--- a/src/FubarCoder.RestSharp.Portable.Core/RestClientBase.cs
+++ b/src/FubarCoder.RestSharp.Portable.Core/RestClientBase.cs
@@ -40,9 +40,9 @@ namespace RestSharp.Portable
         /// <param name="httpClientFactory">The HTTP client factory to use</param>
         protected RestClientBase(IHttpClientFactory httpClientFactory)
         {
-            _httpClient = new Lazy<IHttpClient>(() => httpClientFactory.CreateClient(this));
-
             HttpClientFactory = httpClientFactory;
+            
+            _httpClient = new Lazy<IHttpClient>(() => this.HttpClientFactory.CreateClient(this));
 
             // register default handlers
             var jsonDeserializer = new JsonDeserializer();


### PR DESCRIPTION
At the moment, if you set the HttpClientFactory property on RestClientBase, it uses the original property sent in by the constructor.

This PR will allow you to set the HttpClientFactory and then when the HttpClient is created, it will use the new one, and not the original from the ctor arg.